### PR TITLE
Add extract option to abort on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ mvn test
 
 The compiled jar ```elf-cmd.jar``` can be executed from the command line in different modes:
 1. *Validator:*  ```java -jar elf-cmd.jar validate <PATH_TO_SCRIPT> (-errors|-full)?``` executes the validator on the specified script. There are two options for validation: whereas ```-errors``` only reports specification errors, the default option is ```-full``` and also includes warnings and infos. 
-2. *Extractor:*   ```java -jar elf-cmd.jar extractor <PATH_TO_SCRIPT>``` executes the extractor and retrieves the data as specified in the script.
+2. *Extractor:*   ```java -jar elf-cmd.jar extract <PATH_TO_SCRIPT>``` executes the extractor and retrieves the data as specified in the script.
 3. *Generator:* ```java -jar elf-cmd.jar generate <PATH_TO_SCRIPT>``` executes the generation of efficient logging code for the script.
 
 ## License

--- a/src/main/java/au/csiro/data61/aap/elf/ElfApp.java
+++ b/src/main/java/au/csiro/data61/aap/elf/ElfApp.java
@@ -12,6 +12,7 @@ public class ElfApp {
     private static final String CMD_GENERATE = "generate";
     private static final String CMD_EXTRACT = "extract";
     private static final String CMD_VALIDATE = "validate";
+    private static final String ABORT_EXTRACTION_MODE = "-abort";
     private static final String FULL_VALIDATION_MODE = "-full";
     private static final String ERROR_VALIDATION_MODE = "-errors";
 
@@ -39,7 +40,21 @@ public class ElfApp {
         if (command.equals(CMD_GENERATE)) {
             generate(filepath);
         } else if (command.equals(CMD_EXTRACT)) {
-            extract(filepath);
+            boolean abortOnError = false;
+            if (INDEX_MODE + 1 <= args.length) {
+                if (args[INDEX_MODE].equals(ABORT_EXTRACTION_MODE)) {
+                    abortOnError = true;
+                } else {
+                    final String message = String.format(
+                        "Invalid extraction mode. Must be '%s' or no argument, but was %s",
+                        ABORT_EXTRACTION_MODE,
+                        args[INDEX_MODE]
+                    );
+                    System.out.println(message);
+                    return;
+                }
+            }
+            extract(filepath, abortOnError);
         } else if (command.equals(CMD_VALIDATE)) {
             boolean errorsOnly = false;
             if (INDEX_MODE + 1 <= args.length) {
@@ -79,11 +94,11 @@ public class ElfApp {
         }
     }
 
-    private static void extract(String filepath) {
+    private static void extract(String filepath, boolean abortOnError) {
         final Extractor extractor = new Extractor();
 
         try {
-            extractor.extractData(filepath);
+            extractor.extractData(filepath, abortOnError);
         } catch (EthqlProcessingException ex) {
             ex.printStackTrace(System.err);
         }

--- a/src/main/java/au/csiro/data61/aap/elf/Extractor.java
+++ b/src/main/java/au/csiro/data61/aap/elf/Extractor.java
@@ -15,7 +15,7 @@ import au.csiro.data61.aap.elf.util.CompositeEthqlListener;
  */
 public class Extractor {
 
-    public void extractData(final String ethqlFilepath) throws EthqlProcessingException {
+    public void extractData(final String ethqlFilepath, boolean abortOnError) throws EthqlProcessingException {
         final ParseTree parseTree = Validator.createParseTree(ethqlFilepath, true);
 
         final CompositeEthqlListener<EthqlListener> rootListener = new CompositeEthqlListener<>();
@@ -32,11 +32,12 @@ public class Extractor {
         }
 
         final Program program = builder.getProgram();
-        this.executeProgram(program);
+        this.executeProgram(program, abortOnError);
     }
 
-    private void executeProgram(Program program) {
+    private void executeProgram(Program program, boolean abortOnError) {
         final ProgramState state = new ProgramState();
+        state.setAbortOnException(abortOnError);
         program.execute(state);
     }
 }

--- a/src/main/java/au/csiro/data61/aap/elf/core/ProgramState.java
+++ b/src/main/java/au/csiro/data61/aap/elf/core/ProgramState.java
@@ -37,6 +37,10 @@ public class ProgramState {
         return this.exceptionHandler;
     }
 
+    public void setAbortOnException(boolean abortOnException) {
+        exceptionHandler.setAbortOnException(abortOnException);
+    }
+
     private void setOutputFolder(String folderPath) throws ProgramException {
         final Path outputFolder = Path.of(folderPath);
         if (!outputFolder.toFile().exists()) {

--- a/src/main/java/au/csiro/data61/aap/samples/ExtractorTest.java
+++ b/src/main/java/au/csiro/data61/aap/samples/ExtractorTest.java
@@ -18,7 +18,7 @@ public class ExtractorTest {
         System.out.println(url.getFile());
 
         try {
-            extractor.extractData(url.getFile());
+            extractor.extractData(url.getFile(), false);
         } catch (Throwable ex) {
             ex.printStackTrace();
         }


### PR DESCRIPTION
This patch allows the command line client to abort on error when running the `extract` command. It does so by adding an optional `-abort` mode to `extract`. Eg

`java -jar <path>/elf-cmd.jar extract scripts/CryptoKitties.ethql -abort`


This is useful when, for example, a network connection goes down. Existing behaviour (and continuing default behaviour) is to keep trying on the next block in the query range.

The functionality to abort on error is already present, this just exposes it to the command line.

Also, this fixes a minor typo in the syntax of the `extract` command in the README.